### PR TITLE
fix: adapt pkgconfig files

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -304,6 +304,9 @@ EOF
 
   echo 'EOF' >> "$exports_path"
   echo '' >> "$exports_path"
+
+  topic "Rewrite package-config files"
+  find "$apt_layer" -type f -ipath '*/pkgconfig/*.pc' -print0 | xargs -0 --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$apt_layer"'\1!g'
 fi
 
 # write layer toml file


### PR DESCRIPTION
pkgconfig use pkgconfig files that help compilation
Each contains a prefix var that is initialized with default value (typically /usr)
This prevent to success in compilation of some lib
Eg. 
* install apt package default-libmysqlclient-dev
* try to install python package mysqlclient -> this fail as pkgconfig does not give right informations

This patch is adapt from heroku pack : https://github.com/heroku/heroku-buildpack-apt/blob/main/bin/compile#L152